### PR TITLE
#47 Update to Senzing 4.2.2

### DIFF
--- a/.github/scripts/docker_test_script.sh
+++ b/.github/scripts/docker_test_script.sh
@@ -7,12 +7,12 @@ if [[ -z "${LD_LIBRARY_PATH}" ]]; then
 fi
 
 # Verify that some Senzing files have been installed
-# /opt/senzing/er/g2BuildVersion.json  (log contents)
-FILE=/opt/senzing/er/g2BuildVersion.json
+# /opt/senzing/er/szBuildVersion.json  (log contents)
+FILE=/opt/senzing/er/szBuildVersion.json
 if test -f "$FILE"; then
-    echo "$FILE exists."
+    echo "[INFO] $FILE exists."
 else
-    echo "$FILE does not exist."
+    echo "[ERROR] $FILE does not exist."
     exit 1
 fi
 
@@ -25,7 +25,7 @@ else
     exit 1
 fi
 
-# parse /opt/senzing/er/g2BuildVersion.json, get BUILD_VERSION and compare it with SENZING_APT_INSTALL_PACKAGE="senzingsdk-runtime=3.3.1-22283" 
+# parse /opt/senzing/data/g2BuildVersion.json, get BUILD_VERSION and compare it with SENZING_APT_INSTALL_PACKAGE="senzingsdk-runtime=3.3.1-22283" 
 # {
 #     "PLATFORM": "Linux",
 #     "VERSION": "4.0.0",
@@ -35,7 +35,7 @@ fi
 # }
 
 # check that g2build version is the same as the senzing apt installed 
-FILE=/opt/senzing/er/g2BuildVersion.json
+FILE=/opt/senzing/data/szBuildVersion.json
 if test -f "$FILE"; then
     echo "[INFO] $FILE exists."
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+## [4.2.2] - 2026-03-18
+
+### Changed in 4.2.2
+
+- Based on Senzing 4.2.2
+
 ## [4.2.1] - 2026-02-20
 
 ### Changed in 4.2.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG SENZING_APT_INSTALL_PACKAGE="senzingsdk-runtime"
 ARG SENZING_APT_REPOSITORY_NAME="senzingrepo_2.0.1-1_all.deb"
 ARG SENZING_APT_REPOSITORY_URL="https://senzing-production-apt.s3.amazonaws.com"
 
-ENV REFRESHED_AT=2026-02-20
+ENV REFRESHED_AT=2026-03-18
 
 ENV SENZING_ACCEPT_EULA=${SENZING_ACCEPT_EULA} \
     SENZING_APT_INSTALL_PACKAGE=${SENZING_APT_INSTALL_PACKAGE} \
@@ -17,8 +17,8 @@ ENV SENZING_ACCEPT_EULA=${SENZING_ACCEPT_EULA} \
 
 LABEL Name="senzing/senzingsdk-runtime" \
       Maintainer="support@senzing.com" \
-      Version="4.2.1" \
-      SenzingSDK="4.2.1"
+      Version="4.2.2" \
+      SenzingSDK="4.2.2"
 
 # Run as "root" for system installation.
 


### PR DESCRIPTION
## Summary

- Updated Dockerfile version labels and `REFRESHED_AT` date for Senzing 4.2.2
- Added CHANGELOG entry for 4.2.2
- Updated test script to use `szBuildVersion.json` and improved log prefixes

## Which issue does this address

Resolves #47

---

Resolves #47