### PR TITLE
#62 don't sign staging images

### DIFF
--- a/.github/workflows/docker-push-containers-to-dockerhub.yaml
+++ b/.github/workflows/docker-push-containers-to-dockerhub.yaml
@@ -49,9 +49,7 @@ jobs:
   docker-push-staging:
     if: github.ref == 'refs/heads/main'
     permissions:
-      attestations: write
-      contents: write
-      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -72,7 +70,7 @@ jobs:
           image-tag: staging
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
           push: true
-          sign-image: true
+          sign-image: false
           skip-latest-tag: true
           username: ${{ secrets.DOCKERHUB_USERNAME }}
 


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #62 

Summary

Disable cosign signing and SBOM/provenance attestations on the staging Docker image build. Production semver releases continue to be signed.

Why

Every staging build pushes a new sha256-<digest>.sig (and .att / .sbom) tag to Docker Hub alongside the image. Because staging is rebuilt on every merge to main and again nightly via cron, these tags accumulate indefinitely in the registry. Docker Hub's UI doesn't filter signature tags the way ECR or Quay do, so they show up in the public tag list at https://hub.docker.com/r/senzing/senzingsdk-runtime/tags and visually clutter the release history.

Beyond the noise, the accumulated staging signatures aren't doing much work:

- Signatures bind to image digests, not tags. They prove "this digest was built by the Senzing publish workflow," not "this is the canonical Senzing release."
- For an immutable semver release (4.4.0), that proof is load-bearing forever — the tag is intended to point to that digest in perpetuity, so the .sig is anchored to something durable that consumers can re-verify later.
- For staging, the tag is re-pointed every build by design. As soon as staging moves on, last week's .sig is for a digest no one's pulling. The signature is still cryptographically valid, but the practical claim it backs is stale.

Build provenance for non-release builds is still recorded in GitHub's attestation log automatically; this PR only stops publishing those artifacts to the public registry.

---

Resolves #62